### PR TITLE
Update help command to include the rss group

### DIFF
--- a/PodcastPlayerDiscordBot/Commands/Info.cs
+++ b/PodcastPlayerDiscordBot/Commands/Info.cs
@@ -40,7 +40,7 @@ namespace PodcastPlayerDiscordBot.Commands
             {
                 builder.AppendLine("------------------------------");
 				
-				builder.Append("**");
+                builder.Append("**");
 
                 if (command.Module.Name == "rss")
                 {

--- a/PodcastPlayerDiscordBot/Commands/Info.cs
+++ b/PodcastPlayerDiscordBot/Commands/Info.cs
@@ -39,8 +39,17 @@ namespace PodcastPlayerDiscordBot.Commands
             foreach(var command in _commands.Commands)
             {
                 builder.AppendLine("------------------------------");
-                builder.AppendLine($"**{command.Name}**");
+				
+				builder.Append("**");
+
+                if (command.Module.Name == "rss")
+                {
+                    builder.Append($"{command.Module.Name} ");
+                }
+
+                builder.AppendLine($"{command.Name}**");
                 builder.AppendLine($"*{command.Summary}*");
+				
                 foreach(var parameter in command.Parameters)
                 {
                     var requiredFlag = parameter.IsOptional ? "" : " *required*";


### PR DESCRIPTION
Quick and dirty hack for #2 - appends "rss" to the front of the command name if it's in the RSS module. I was unable to get a more automatic solution to work, unfortunately.